### PR TITLE
Update the source of git-prune plugin

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -13,7 +13,7 @@ antigen bundle command-not-found
 antigen bundle zsh-users/zsh-syntax-highlighting
 
 # Easy cleanup of git branches
-antigen bundle Seinh/git-prune
+antigen bundle diazod/git-prune
 
 # Load the theme.
 antigen theme minimal


### PR DESCRIPTION
Hey, I was copying your zshrc (😅 ) and noticed that one of the plugin has changed its source(See https://github.com/diazod/git-prune) . Just an FYI if you wanted to update it as well.